### PR TITLE
Add save button for service settings

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -286,6 +286,13 @@ button:disabled {
 #save-settings-button:hover {
   background-color: #218838;
 }
+#save-filtering-button {
+  margin-top: 20px;
+  background-color: #28a745;
+}
+#save-filtering-button:hover {
+  background-color: #218838;
+}
 .details-content pre {
   background-color: #e9ecef;
   padding: 15px;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -29,6 +29,9 @@ document.addEventListener("DOMContentLoaded", () => {
     "openai-mappings-container"
   );
   const settingsFeedback = document.getElementById("settings-feedback");
+  const saveSettingsButton = document.getElementById("save-settings-button");
+  const saveFilteringButton = document.getElementById("save-filtering-button");
+  const filteringFeedback = document.getElementById("filtering-feedback");
   const charCounter = document.getElementById("char-counter");
   const autoPlayCheckbox = document.getElementById("auto-play");
   const concurrencyInput = document.getElementById("concurrency-input");
@@ -144,7 +147,7 @@ document.addEventListener("DOMContentLoaded", () => {
     updateApiExamples();
   };
 
-  const autoSaveConfig = () => {
+  const collectConfig = () => {
     const newConfig = {
       port: parseInt(portInput.value, 10),
       api_token: apiTokenInput.value.trim(),
@@ -165,6 +168,12 @@ document.addEventListener("DOMContentLoaded", () => {
       if (select) newConfig.openai_voice_map[alias] = select.value;
     });
 
+    return newConfig;
+  };
+
+  const saveConfig = (feedbackTarget) => {
+    const newConfig = collectConfig();
+
     fetch("/v1/config", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -175,11 +184,12 @@ document.addEventListener("DOMContentLoaded", () => {
         return response.json();
       })
       .then((result) => {
-        console.log("Config auto-saved:", result.message);
+        console.log("Config saved:", result.message);
         currentConfig = newConfig;
+        showMessage(feedbackTarget, "设置已保存");
       })
       .catch((error) =>
-        showMessage(settingsFeedback, "自动保存设置失败!", true)
+        showMessage(feedbackTarget, "保存设置失败!", true)
       );
   };
 
@@ -282,23 +292,16 @@ document.addEventListener("DOMContentLoaded", () => {
       speakButton.addEventListener("click", handleSpeakClick);
       generateTokenButton.addEventListener("click", () => {
         apiTokenInput.value = generateRandomToken();
-        autoSaveConfig();
         updateApiExamples();
       });
       apiTokenInput.addEventListener("input", updateApiExamples);
 
-      // 为所有配置项绑定自动保存事件
-      document
-        .querySelector(".details-content")
-        .addEventListener("change", (event) => {
-          if (
-            event.target.matches(
-              ".settings-input, #cleaning-options-panel input"
-            )
-          ) {
-            autoSaveConfig();
-          }
-        });
+      saveSettingsButton.addEventListener("click", () =>
+        saveConfig(settingsFeedback)
+      );
+      saveFilteringButton.addEventListener("click", () =>
+        saveConfig(filteringFeedback)
+      );
 
       const defaultLang = "zh-CN";
       languageSelect.value = defaultLang;

--- a/templates/index.html
+++ b/templates/index.html
@@ -34,8 +34,8 @@
                 id="sync-api-filtering"
                 name="sync_api_filtering"
               />
-              对所有 API
-              调用应用以下过滤规则以及服务器设置(重复点当做保存懒得改了😄)
+              对所有 API 调用应用以下过滤规则。
+              修改后需点击下方保存按钮才会生效
             </label>
           </div>
           <hr />
@@ -69,6 +69,8 @@
               />
             </div>
           </div>
+          <button id="save-filtering-button">保存过滤设置</button>
+          <div id="filtering-feedback" class="feedback" style="display: none"></div>
         </div>
       </details>
 
@@ -200,7 +202,7 @@
           <div id="openai-mappings-container">
             <div class="spinner-wrapper"><div class="spinner"></div></div>
           </div>
-          <!-- 移除独立的保存按钮 -->
+          <button id="save-settings-button">保存设置</button>
           <div
             id="settings-feedback"
             class="feedback"


### PR DESCRIPTION
## Summary
- add Save button under service settings section
- refactor JS: gather config, save on button click, remove autosave
- add independent save for filtering options

## Testing
- `python -m py_compile app.py`
- `node --check static/js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_6853a33c1a8c83339fdc4941bcb01240