### PR TITLE
Fix config saving and logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,7 +68,9 @@ def initialize_config():
         config = loaded_config
         if updated: save_config_to_file(config)
     MAX_CONCURRENT_REQUESTS = config.get("max_concurrent_requests", 20)
-    logger.info(f"Configuration loaded. Max concurrent requests set to: {MAX_CONCURRENT_REQUESTS}")
+    logger.info(
+        f"Configuration loaded. Port: {config.get('port')} - Max concurrent requests: {MAX_CONCURRENT_REQUESTS}"
+    )
 
 def parse_voices():
     global ALL_VOICES, SUPPORTED_LOCALES
@@ -246,7 +248,9 @@ def get_all_voices(): return jsonify(ALL_VOICES)
 
 @app.route('/v1/config', methods=['GET'])
 @login_required
-def get_config(): return jsonify(config)
+def get_config():
+    logger.info("Configuration requested via API.")
+    return jsonify(config)
 
 @app.route('/v1/config', methods=['POST'])
 @login_required
@@ -259,7 +263,9 @@ def update_config():
         config.update(new_data)
         MAX_CONCURRENT_REQUESTS = config.get("max_concurrent_requests", 20)
         save_config_to_file(config)
-        logger.info(f"Configuration updated. Max concurrent requests set to: {MAX_CONCURRENT_REQUESTS}")
+        logger.info(
+            f"Configuration updated. Port: {config.get('port')} - Max concurrent requests set to: {MAX_CONCURRENT_REQUESTS}"
+        )
         return jsonify({"message": "设置已保存。"})
     except Exception as e:
         logger.error(f"Error updating config: {e}", exc_info=True)

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -172,7 +172,6 @@ document.addEventListener("DOMContentLoaded", () => {
   };
 
   const saveConfig = (feedbackTarget) => {
-  const saveConfig = () => {
     const newConfig = collectConfig();
 
     fetch("/v1/config", {
@@ -187,16 +186,12 @@ document.addEventListener("DOMContentLoaded", () => {
       .then((result) => {
         console.log("Config saved:", result.message);
         currentConfig = newConfig;
-
         showMessage(feedbackTarget, "设置已保存");
       })
-      .catch((error) =>
-        showMessage(feedbackTarget, "保存设置失败!", true)
-        showMessage(settingsFeedback, "设置已保存");
-      })
-      .catch((error) =>
-        showMessage(settingsFeedback, "保存设置失败!", true)
-      );
+      .catch((error) => {
+        console.error("Error saving config:", error);
+        showMessage(feedbackTarget, "保存设置失败!", true);
+      });
   };
 
   const handleSpeakClick = async () => {
@@ -307,7 +302,6 @@ document.addEventListener("DOMContentLoaded", () => {
       saveFilteringButton.addEventListener("click", () =>
         saveConfig(filteringFeedback)
       );
-      saveSettingsButton.addEventListener("click", saveConfig);
 
       const defaultLang = "zh-CN";
       languageSelect.value = defaultLang;


### PR DESCRIPTION
## Summary
- fix syntax error in JS saveConfig and update event listeners
- log port and concurrency on config load and update
- log when config is fetched via API

## Testing
- `python -m py_compile app.py`
- `node --check static/js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_6853b7c3d8f08333a51e8ddbf06a0478