### PR TITLE
Add language/theme toggle

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -12,6 +12,22 @@ body {
   min-height: 100vh;
   box-sizing: border-box;
 }
+.top-bar {
+  position: absolute;
+  top: 10px;
+  right: 20px;
+  display: flex;
+  gap: 10px;
+}
+.top-bar button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+}
+.top-bar button:hover {
+  text-decoration: underline;
+}
 .container {
   background-color: #fff;
   padding: 30px 40px;
@@ -416,4 +432,27 @@ hr {
   border: none;
   border-top: 1px solid #dee2e6;
   margin: 15px 0;
+}
+
+/* Dark theme overrides */
+body.dark-theme {
+  background-color: #121212;
+  color: #e1e1e1;
+}
+body.dark-theme .container {
+  background-color: #1e1e1e;
+  color: #e1e1e1;
+}
+body.dark-theme input,
+body.dark-theme textarea,
+body.dark-theme select {
+  background-color: #2c2c2c;
+  color: #e1e1e1;
+  border-color: #555;
+}
+body.dark-theme .site-footer {
+  border-top-color: #555;
+}
+body.dark-theme .api-sync-toggle {
+  background-color: #2c3a55;
 }

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,0 +1,152 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const translations = {
+    zh: {
+      title: '本地多语言 TTS 服务',
+      desc: '基于 Microsoft Edge TTS 引擎，支持多种语言和音色。',
+      input_label: '输入文本:',
+      input_placeholder: '在这里输入要转换为语音的文本...',
+      char_count: '字数:',
+      filter_options: '文本过滤选项',
+      api_sync_note: '对所有 API 调用应用以下过滤规则。',
+      api_sync_save: '修改后需点击下方保存按钮才会生效',
+      remove_markdown: '移除 Markdown 语法',
+      remove_emoji: '移除表情符号',
+      remove_url: '移除 URL 链接',
+      merge_line: '合并为单行文本',
+      custom_keywords: '自定义移除关键词 (用英文逗号,分隔):',
+      custom_placeholder: '例如：附注,图表,免责声明',
+      save_filter: '保存过滤设置',
+      select_lang: '选择语言:',
+      select_lang_option: '-- 选择语言 --',
+      select_voice: '选择声音:',
+      choose_lang_first: '请先选择语言',
+      auto_play: '生成后自动播放',
+      gen_speech: '🎵 生成语音',
+      download_audio: '下载音频',
+      service_settings: '服务设置',
+      service_port: '服务端口:',
+      concurrency: '并发数:',
+      port_hint: '端口修改需重启服务。并发数保存后立即对新请求生效。',
+      api_token: 'API 密钥 (留空则不验证):',
+      empty_api_hint: '留空则任何人都可以调用 API',
+      gen_token: '生成随机密钥',
+      openai_map: 'OpenAI 音色映射',
+      save_settings: '保存设置',
+      api_guide: 'API 配置指引',
+      api_endpoint: 'API 端点',
+      api_post: '所有请求都使用 POST 方法发送到以下地址:',
+      guide_openai: '1. OpenAI 兼容格式 (推荐)',
+      openai_tip: '使用 OpenAI 的标准音色名 (`shimmer`, `alloy` 等) 调用，服务会自动映射到您在上面设置中选择的音色。',
+      generating_example: '正在生成示例...',
+      guide_direct: '2. EdgeTTS 直接格式',
+      direct_tip: '直接使用 EdgeTTS 的完整音色名称进行调用。这种方式会绕过您的 OpenAI 音色映射设置。',
+      login_title: '登录 - 本地 TTS 服务',
+      login_header: '登录到 TTS 服务',
+      login_tip: '此服务已启用密码保护。',
+      password_label: '密码:',
+      login_button: '登 录'
+    },
+    en: {
+      title: 'Local Multi-language TTS Service',
+      desc: 'Powered by Microsoft Edge TTS engine with multiple languages and voices.',
+      input_label: 'Input text:',
+      input_placeholder: 'Type the text to convert into speech here...',
+      char_count: 'Characters:',
+      filter_options: 'Text Cleaning Options',
+      api_sync_note: 'Apply these filters to all API calls.',
+      api_sync_save: 'Changes take effect after saving below',
+      remove_markdown: 'Remove Markdown syntax',
+      remove_emoji: 'Remove emoji',
+      remove_url: 'Remove URL links',
+      merge_line: 'Merge lines into one',
+      custom_keywords: 'Custom keywords to remove (comma separated):',
+      custom_placeholder: 'e.g. note,diagram,disclaimer',
+      save_filter: 'Save filter settings',
+      select_lang: 'Select language:',
+      select_lang_option: '-- Select language --',
+      select_voice: 'Select voice:',
+      choose_lang_first: 'Please select a language first',
+      auto_play: 'Auto play after generation',
+      gen_speech: '🎵 Generate Speech',
+      download_audio: 'Download audio',
+      service_settings: 'Service Settings',
+      service_port: 'Service Port:',
+      concurrency: 'Concurrency:',
+      port_hint: 'Port change requires restart. Concurrency takes effect immediately.',
+      api_token: 'API token (leave blank to disable auth):',
+      empty_api_hint: 'Leave empty to allow anyone to call API',
+      gen_token: 'Generate random token',
+      openai_map: 'OpenAI Voice Mapping',
+      save_settings: 'Save Settings',
+      api_guide: 'API Usage Guide',
+      api_endpoint: 'API Endpoint',
+      api_post: 'Send POST requests to this endpoint:',
+      guide_openai: '1. OpenAI compatible format (recommended)',
+      openai_tip: 'Use standard OpenAI voice names (e.g. shimmer, alloy). They will be mapped to your selected voices.',
+      generating_example: 'Generating example...',
+      guide_direct: '2. EdgeTTS direct format',
+      direct_tip: 'Call using the full EdgeTTS voice name directly. This bypasses your OpenAI mapping.',
+      login_title: 'Login - Local TTS Service',
+      login_header: 'Login to TTS Service',
+      login_tip: 'This service is password protected.',
+      password_label: 'Password:',
+      login_button: 'Log in'
+    }
+  };
+  window.translations = translations;
+
+  const langToggle = document.getElementById('lang-toggle');
+  const themeToggle = document.getElementById('theme-toggle');
+
+  let currentLang = localStorage.getItem('lang') || 'zh';
+  window.currentLang = currentLang;
+  applyLang(currentLang);
+  if (langToggle) {
+    langToggle.textContent = currentLang === 'zh' ? 'EN' : '中文';
+    langToggle.addEventListener('click', () => {
+      currentLang = currentLang === 'zh' ? 'en' : 'zh';
+      localStorage.setItem('lang', currentLang);
+      applyLang(currentLang);
+      window.currentLang = currentLang;
+      langToggle.textContent = currentLang === 'zh' ? 'EN' : '中文';
+    });
+  }
+
+  let currentTheme = localStorage.getItem('theme') || 'light';
+  window.currentTheme = currentTheme;
+  applyTheme(currentTheme);
+  if (themeToggle) {
+    themeToggle.textContent = currentTheme === 'dark' ? '☀' : '🌙';
+    themeToggle.addEventListener('click', () => {
+      currentTheme = currentTheme === 'light' ? 'dark' : 'light';
+      localStorage.setItem('theme', currentTheme);
+      applyTheme(currentTheme);
+      window.currentTheme = currentTheme;
+      themeToggle.textContent = currentTheme === 'dark' ? '☀' : '🌙';
+    });
+  }
+
+  function applyTheme(theme) {
+    document.body.classList.toggle('dark-theme', theme === 'dark');
+  }
+
+  function applyLang(lang) {
+    document.documentElement.lang = lang === 'zh' ? 'zh-CN' : 'en';
+    document.querySelectorAll('[data-i18n]').forEach((el) => {
+      const key = el.getAttribute('data-i18n');
+      if (translations[lang] && translations[lang][key]) {
+        if (el.id === 'char-counter') {
+          el.textContent = `${translations[lang][key]} ${document.getElementById('text-input')?.value.length || 0}`;
+        } else {
+          el.textContent = translations[lang][key];
+        }
+      }
+    });
+    document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
+      const key = el.getAttribute('data-i18n-placeholder');
+      if (translations[lang] && translations[lang][key]) {
+        el.setAttribute('placeholder', translations[lang][key]);
+      }
+    });
+  }
+});

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -263,8 +263,11 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   };
 
-  const updateCharCount = () =>
-    (charCounter.textContent = `字数: ${textInput.value.length}`);
+  const updateCharCount = () => {
+    const lang = window.currentLang || 'zh';
+    const label = (window.translations && window.translations[lang]?.char_count) || '字数:';
+    charCounter.textContent = `${label} ${textInput.value.length}`;
+  };
 
   const generateRandomToken = () => {
     const array = new Uint8Array(16);

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,29 +3,34 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>本地多语言 TTS 服务</title>
+    <title data-i18n="title">本地多语言 TTS 服务</title>
     <link
       rel="stylesheet"
       href="{{ url_for('static', filename='css/style.css') }}"
     />
   </head>
   <body>
+    <div class="top-bar">
+      <button id="theme-toggle" title="Toggle theme">🌙</button>
+      <button id="lang-toggle">EN</button>
+    </div>
     <div class="container">
-      <h1>本地多语言 TTS 服务</h1>
-      <p>基于 Microsoft Edge TTS 引擎，支持多种语言和音色。</p>
+      <h1 data-i18n="title">本地多语言 TTS 服务</h1>
+      <p data-i18n="desc">基于 Microsoft Edge TTS 引擎，支持多种语言和音色。</p>
 
       <div class="form-group">
-        <label for="text-input">输入文本:</label>
+        <label for="text-input" data-i18n="input_label">输入文本:</label>
         <textarea
           id="text-input"
           rows="5"
+          data-i18n-placeholder="input_placeholder"
           placeholder="在这里输入要转换为语音的文本..."
         ></textarea>
-        <div id="char-counter" class="char-counter">字数: 0</div>
+        <div id="char-counter" class="char-counter" data-i18n="char_count">字数: 0</div>
       </div>
 
       <details class="collapsible-section small">
-        <summary>文本过滤选项</summary>
+        <summary data-i18n="filter_options">文本过滤选项</summary>
         <div class="details-content" id="cleaning-options-panel">
           <div class="form-group api-sync-toggle">
             <label class="checkbox-label">
@@ -34,60 +39,62 @@
                 id="sync-api-filtering"
                 name="sync_api_filtering"
               />
-              对所有 API 调用应用以下过滤规则。
-              修改后需点击下方保存按钮才会生效
+              <span data-i18n="api_sync_note">对所有 API 调用应用以下过滤规则。</span>
+              <span data-i18n="api_sync_save">修改后需点击下方保存按钮才会生效</span>
             </label>
           </div>
           <hr />
           <div id="cleaning-options">
             <div class="option-grid">
               <label class="checkbox-label"
-                ><input type="checkbox" name="remove_markdown" /> 移除 Markdown
-                语法</label
+                ><input type="checkbox" name="remove_markdown" />
+                <span data-i18n="remove_markdown">移除 Markdown 语法</span></label
               >
               <label class="checkbox-label"
                 ><input type="checkbox" name="remove_emoji" />
-                移除表情符号</label
+                <span data-i18n="remove_emoji">移除表情符号</span></label
               >
               <label class="checkbox-label"
-                ><input type="checkbox" name="no_urls" /> 移除 URL 链接</label
+                ><input type="checkbox" name="no_urls" />
+                <span data-i18n="remove_url">移除 URL 链接</span></label
               >
               <label class="checkbox-label"
                 ><input type="checkbox" name="no_line_breaks" />
-                合并为单行文本</label
+                <span data-i18n="merge_line">合并为单行文本</span></label
               >
             </div>
             <div class="form-group" style="margin-top: 15px; margin-bottom: 0">
-              <label for="custom-keywords"
+              <label for="custom-keywords" data-i18n="custom_keywords"
                 >自定义移除关键词 (用英文逗号,分隔):</label
               >
               <input
                 type="text"
                 id="custom-keywords"
                 class="settings-input"
+                data-i18n-placeholder="custom_placeholder"
                 placeholder="例如：附注,图表,免责声明"
               />
             </div>
           </div>
-          <button id="save-filtering-button">保存过滤设置</button>
+          <button id="save-filtering-button" data-i18n="save_filter">保存过滤设置</button>
           <div id="filtering-feedback" class="feedback" style="display: none"></div>
         </div>
       </details>
 
       <div class="form-group-inline">
         <div class="form-group">
-          <label for="language-select">选择语言:</label>
+          <label for="language-select" data-i18n="select_lang">选择语言:</label>
           <select id="language-select">
-            <option value="">-- 选择语言 --</option>
+            <option value="" data-i18n="select_lang_option">-- 选择语言 --</option>
             {% for code, name in locales.items() %}
             <option value="{{ code }}">{{ name }}</option>
             {% endfor %}
           </select>
         </div>
         <div class="form-group">
-          <label for="voice-select">选择声音:</label>
+          <label for="voice-select" data-i18n="select_voice">选择声音:</label>
           <select id="voice-select" disabled>
-            <option>请先选择语言</option>
+            <option data-i18n="choose_lang_first">请先选择语言</option>
           </select>
         </div>
       </div>
@@ -95,12 +102,12 @@
       <div class="form-group">
         <label class="checkbox-label">
           <input type="checkbox" id="auto-play" checked />
-          生成后自动播放
+          <span data-i18n="auto_play">生成后自动播放</span>
         </label>
       </div>
 
       <button id="speak-button">
-        <span class="button-text">🎵 生成语音</span>
+        <span class="button-text" data-i18n="gen_speech">🎵 生成语音</span>
         <div class="spinner" style="display: none"></div>
       </button>
 
@@ -122,6 +129,7 @@
           class="icon-button"
           download="tts_output.mp3"
           title="下载音频"
+          data-i18n="download_audio"
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -144,15 +152,15 @@
       <div id="error-message" class="error" style="display: none"></div>
 
       <details class="collapsible-section">
-        <summary>服务设置</summary>
+        <summary data-i18n="service_settings">服务设置</summary>
         <div class="details-content">
           <div class="settings-grid">
             <div class="form-group">
-              <label for="port-input">服务端口:</label>
+              <label for="port-input" data-i18n="service_port">服务端口:</label>
               <input type="number" id="port-input" class="settings-input" />
             </div>
             <div class="form-group">
-              <label for="concurrency-input">并发数:</label>
+              <label for="concurrency-input" data-i18n="concurrency">并发数:</label>
               <input
                 type="number"
                 id="concurrency-input"
@@ -162,23 +170,25 @@
               />
             </div>
           </div>
-          <p class="settings-hint">
+          <p class="settings-hint" data-i18n="port_hint">
             端口修改需重启服务。并发数保存后立即对新请求生效。
           </p>
 
           <div class="form-group">
-            <label for="api-token-input">API 密钥 (留空则不验证):</label>
+            <label for="api-token-input" data-i18n="api_token">API 密钥 (留空则不验证):</label>
             <div class="input-with-button">
               <input
                 type="text"
                 id="api-token-input"
                 class="settings-input"
+                data-i18n-placeholder="empty_api_hint"
                 placeholder="留空则任何人都可以调用 API"
               />
               <button
                 id="generate-token-button"
                 class="icon-button"
                 title="生成随机密钥"
+                data-i18n="gen_token"
               >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -198,11 +208,11 @@
               </button>
             </div>
           </div>
-          <h3>OpenAI 音色映射</h3>
+          <h3 data-i18n="openai_map">OpenAI 音色映射</h3>
           <div id="openai-mappings-container">
             <div class="spinner-wrapper"><div class="spinner"></div></div>
           </div>
-          <button id="save-settings-button">保存设置</button>
+          <button id="save-settings-button" data-i18n="save_settings">保存设置</button>
           <div
             id="settings-feedback"
             class="feedback"
@@ -212,23 +222,23 @@
       </details>
 
       <details class="collapsible-section">
-        <summary>API 配置指引</summary>
+        <summary data-i18n="api_guide">API 配置指引</summary>
         <div class="details-content">
-          <h3>API 端点</h3>
-          <p>所有请求都使用 POST 方法发送到以下地址:</p>
+          <h3 data-i18n="api_endpoint">API 端点</h3>
+          <p data-i18n="api_post">所有请求都使用 POST 方法发送到以下地址:</p>
           <pre><code id="api-endpoint-display">正在获取地址...</code></pre>
-          <h3>1. OpenAI 兼容格式 (推荐)</h3>
+          <h3 data-i18n="guide_openai">1. OpenAI 兼容格式 (推荐)</h3>
           <p>
-            使用 OpenAI 的标准音色名 (`shimmer`, `alloy` 等)
-            调用，服务会自动映射到您在上面设置中选择的音色。
+            <span data-i18n="openai_tip">使用 OpenAI 的标准音色名 (`shimmer`, `alloy` 等)
+            调用，服务会自动映射到您在上面设置中选择的音色。</span>
           </p>
-          <pre><code id="curl-example-openai">正在生成示例...</code></pre>
-          <h3>2. EdgeTTS 直接格式</h3>
+          <pre><code id="curl-example-openai" data-i18n="generating_example">正在生成示例...</code></pre>
+          <h3 data-i18n="guide_direct">2. EdgeTTS 直接格式</h3>
           <p>
-            直接使用 EdgeTTS 的完整音色名称进行调用。这种方式会绕过您的 OpenAI
-            音色映射设置。
+            <span data-i18n="direct_tip">直接使用 EdgeTTS 的完整音色名称进行调用。这种方式会绕过您的 OpenAI
+            音色映射设置。</span>
           </p>
-          <pre><code id="curl-example-direct">正在生成示例...</code></pre>
+          <pre><code id="curl-example-direct" data-i18n="generating_example">正在生成示例...</code></pre>
         </div>
       </details>
 
@@ -245,6 +255,7 @@
         </a>
       </footer>
     </div>
+    <script src="{{ url_for('static', filename='js/common.js') }}"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
   </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>登录 - 本地 TTS 服务</title>
+    <title data-i18n="login_title">登录 - 本地 TTS 服务</title>
     <link
       rel="stylesheet"
       href="{{ url_for('static', filename='css/style.css') }}"
@@ -48,13 +48,17 @@
     </style>
   </head>
   <body>
+    <div class="top-bar">
+      <button id="theme-toggle" title="Toggle theme">🌙</button>
+      <button id="lang-toggle">EN</button>
+    </div>
     <div class="container login-container">
-      <h1>登录到 TTS 服务</h1>
-      <p>此服务已启用密码保护。</p>
+      <h1 data-i18n="login_header">登录到 TTS 服务</h1>
+      <p data-i18n="login_tip">此服务已启用密码保护。</p>
       <form method="post" id="login-form">
         <input type="hidden" name="next" id="next-url" />
         <div class="form-group">
-          <label for="password">密码:</label>
+          <label for="password" data-i18n="password_label">密码:</label>
           <input
             type="password"
             id="password"
@@ -67,7 +71,7 @@
         {% if error %}
         <div class="error" style="display: block">{{ error }}</div>
         {% endif %}
-        <button type="submit">登 录</button>
+        <button type="submit" data-i18n="login_button">登 录</button>
       </form>
     </div>
 
@@ -78,6 +82,8 @@
         </a>
       </p>
     </footer>
+
+    <script src="{{ url_for('static', filename='js/common.js') }}"></script>
 
     <script>
       // 这段脚本会在页面加载时，智能地设置重定向 URL


### PR DESCRIPTION
## Summary
- add a reusable `common.js` with translation dictionary and theme switcher
- translate main pages and add language/theme toggle buttons
- apply dark mode styles
- show translated char count dynamically

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6853c153a6848333886dd601adbd243a