### PR TITLE
Add Tailwind class dark mode toggle

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -10,15 +10,13 @@
         darkMode: 'class'
       };
     </script>
-    <script>
-      tailwind.config = { darkMode: 'class' };
-    </script>
-    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="min-h-screen flex flex-col items-center p-4 bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
     <div class="absolute top-2 right-4 flex gap-2">
-      <button id="theme-toggle" title="Toggle theme" class="px-3 py-1 rounded-xl shadow-md bg-green-500 text-white transition-all hover:bg-green-600">🌙</button>
-      <button id="lang-toggle" class="px-3 py-1 rounded-xl shadow-md bg-green-500 text-white transition-all hover:bg-green-600">EN</button>
+      <button onclick="document.documentElement.classList.toggle('dark')" class="p-2 rounded bg-gray-200 dark:bg-gray-700 text-sm text-gray-900 dark:text-white shadow transition-all">
+        🌗 切换模式
+      </button>
+      <button id="lang-toggle" class="bg-green-500 hover:bg-green-600 text-white py-2 px-4 rounded-xl shadow transition">EN</button>
     </div>
     <div class="container bg-white dark:bg-gray-800 shadow-md rounded-xl p-8 w-full max-w-3xl">
       <h1 class="text-3xl font-bold text-center mb-4" data-i18n="title">本地多语言 TTS 服务</h1>
@@ -29,7 +27,7 @@
         <textarea
           id="text-input"
           rows="5"
-          class="w-full p-3 border border-gray-300 dark:border-gray-600 rounded-xl bg-white dark:bg-gray-700 focus:ring focus:ring-green-500 transition-all"
+          class="w-full p-3 border border-gray-300 rounded-xl dark:bg-gray-800 dark:border-gray-600 text-gray-900 dark:text-white"
           data-i18n-placeholder="input_placeholder"
           placeholder="在这里输入要转换为语音的文本..."
         ></textarea>
@@ -52,9 +50,9 @@
     </div>
     <div class="mt-3">
       <label for="custom-keywords" class="font-semibold" data-i18n="custom_keywords">自定义移除关键词 (用英文逗号,分隔):</label>
-      <input type="text" id="custom-keywords" class="w-full mt-1 p-2 border rounded-xl dark:bg-gray-700 dark:border-gray-600" data-i18n-placeholder="custom_placeholder" placeholder="例如：附注,图表,免责声明" />
+      <input type="text" id="custom-keywords" class="w-full mt-1 p-3 border border-gray-300 rounded-xl dark:bg-gray-800 dark:border-gray-600 text-gray-900 dark:text-white" data-i18n-placeholder="custom_placeholder" placeholder="例如：附注,图表,免责声明" />
     </div>
-    <button id="save-filtering-button" class="mt-2 px-4 py-2 rounded-xl bg-green-500 text-white shadow-md transition-all hover:bg-green-600" data-i18n="save_filter">保存过滤设置</button>
+    <button id="save-filtering-button" class="mt-2 bg-green-500 hover:bg-green-600 text-white py-2 px-4 rounded-xl shadow transition" data-i18n="save_filter">保存过滤设置</button>
     <div id="filtering-feedback" class="hidden text-center"></div>
   </div>
 </details>
@@ -82,7 +80,7 @@
         <label for="auto-play" data-i18n="auto_play">生成后自动播放</label>
       </div>
 
-      <button id="speak-button" class="w-full py-3 rounded-xl bg-green-500 text-white shadow-md transition-all hover:bg-green-600 flex justify-center items-center mb-4">
+      <button id="speak-button" class="w-full bg-green-500 hover:bg-green-600 text-white py-2 px-4 rounded-xl shadow transition flex justify-center items-center mb-4">
         <span class="button-text" data-i18n="gen_speech">🎵 生成语音</span>
         <div class="ml-2 w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" style="display: none"></div>
       </button>
@@ -96,7 +94,7 @@
 
       <div id="audio-container" class="flex items-center gap-2 mt-4" style="display: none">
         <audio id="audio-player" controls class="flex-grow"></audio>
-        <a id="download-link" class="px-3 py-2 rounded-xl bg-green-500 text-white shadow-md hover:bg-green-600" download="tts_output.mp3" title="下载音频" data-i18n="download_audio">
+        <a id="download-link" class="bg-green-500 hover:bg-green-600 text-white py-2 px-4 rounded-xl shadow transition" download="tts_output.mp3" title="下载音频" data-i18n="download_audio">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"
@@ -122,19 +120,19 @@
     <div class="grid grid-cols-2 gap-4">
       <div>
         <label for="port-input" class="font-semibold mb-1 block" data-i18n="service_port">服务端口:</label>
-        <input type="number" id="port-input" class="w-full p-2 border rounded-xl dark:bg-gray-700 dark:border-gray-600" />
+        <input type="number" id="port-input" class="w-full p-3 border border-gray-300 rounded-xl dark:bg-gray-800 dark:border-gray-600 text-gray-900 dark:text-white" />
       </div>
       <div>
         <label for="concurrency-input" class="font-semibold mb-1 block" data-i18n="concurrency">并发数:</label>
-        <input type="number" id="concurrency-input" min="1" max="100" class="w-full p-2 border rounded-xl dark:bg-gray-700 dark:border-gray-600" />
+        <input type="number" id="concurrency-input" min="1" max="100" class="w-full p-3 border border-gray-300 rounded-xl dark:bg-gray-800 dark:border-gray-600 text-gray-900 dark:text-white" />
       </div>
     </div>
     <p class="text-sm text-gray-600 dark:text-gray-400" data-i18n="port_hint">端口修改需重启服务。并发数保存后立即对新请求生效。</p>
     <div>
       <label for="api-token-input" class="font-semibold mb-1 block" data-i18n="api_token">API 密钥 (留空则不验证):</label>
       <div class="flex gap-2">
-        <input type="text" id="api-token-input" class="flex-grow p-2 border rounded-xl dark:bg-gray-700 dark:border-gray-600" data-i18n-placeholder="empty_api_hint" placeholder="留空则任何人都可以调用 API" />
-        <button id="generate-token-button" class="px-3 py-2 rounded-xl bg-green-500 text-white shadow-md hover:bg-green-600" title="生成随机密钥" data-i18n="gen_token">
+        <input type="text" id="api-token-input" class="flex-grow p-3 border border-gray-300 rounded-xl dark:bg-gray-800 dark:border-gray-600 text-gray-900 dark:text-white" data-i18n-placeholder="empty_api_hint" placeholder="留空则任何人都可以调用 API" />
+        <button id="generate-token-button" class="bg-green-500 hover:bg-green-600 text-white py-2 px-4 rounded-xl shadow transition" title="生成随机密钥" data-i18n="gen_token">
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>
         </button>
       </div>
@@ -143,7 +141,7 @@
     <div id="openai-mappings-container" class="space-y-2">
       <div class="flex justify-center"><div class="w-6 h-6 border-2 border-green-500 border-t-transparent rounded-full animate-spin"></div></div>
     </div>
-    <button id="save-settings-button" class="px-4 py-2 rounded-xl bg-green-500 text-white shadow-md hover:bg-green-600" data-i18n="save_settings">保存设置</button>
+    <button id="save-settings-button" class="bg-green-500 hover:bg-green-600 text-white py-2 px-4 rounded-xl shadow transition" data-i18n="save_settings">保存设置</button>
     <div id="settings-feedback" class="hidden text-center"></div>
   </div>
 </details>

--- a/templates/login.html
+++ b/templates/login.html
@@ -10,16 +10,13 @@
         darkMode: 'class'
       };
     </script>
-
-    <script>
-      tailwind.config = { darkMode: 'class' };
-    </script>
-    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="min-h-screen flex flex-col items-center justify-center bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
     <div class="absolute top-2 right-4 flex gap-2">
-      <button id="theme-toggle" title="Toggle theme" class="px-3 py-1 rounded-xl shadow-md bg-green-500 text-white transition-all hover:bg-green-600">🌙</button>
-      <button id="lang-toggle" class="px-3 py-1 rounded-xl shadow-md bg-green-500 text-white transition-all hover:bg-green-600">EN</button>
+      <button onclick="document.documentElement.classList.toggle('dark')" class="p-2 rounded bg-gray-200 dark:bg-gray-700 text-sm text-gray-900 dark:text-white shadow transition-all">
+        🌗 切换模式
+      </button>
+      <button id="lang-toggle" class="bg-green-500 hover:bg-green-600 text-white py-2 px-4 rounded-xl shadow transition">EN</button>
     </div>
     <div class="bg-white dark:bg-gray-800 shadow-md rounded-xl p-8 w-full max-w-md text-center">
       <h1 class="text-2xl font-bold mb-2" data-i18n="login_header">登录到 TTS 服务</h1>
@@ -32,7 +29,7 @@
             type="password"
             id="password"
             name="password"
-            class="w-full p-2 border rounded-xl dark:bg-gray-700 dark:border-gray-600"
+            class="w-full p-3 border border-gray-300 rounded-xl dark:bg-gray-800 dark:border-gray-600 text-gray-900 dark:text-white"
             required
             autofocus
           />
@@ -40,7 +37,7 @@
         {% if error %}
         <div class="bg-red-200 text-red-700 p-3 rounded-xl" style="display: block">{{ error }}</div>
         {% endif %}
-        <button type="submit" class="w-full mt-2 px-4 py-2 rounded-xl bg-green-500 text-white shadow-md hover:bg-green-600" data-i18n="login_button">登 录</button>
+        <button type="submit" class="w-full mt-2 bg-green-500 hover:bg-green-600 text-white py-2 px-4 rounded-xl shadow transition" data-i18n="login_button">登 录</button>
       </form>
     </div>
 


### PR DESCRIPTION
## Summary
- load Tailwind CDN before config
- use class-based dark mode
- add dark/light toggle buttons
- update form input/button styles for good contrast

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6853db9d50ec8333a8d53ef7280c43fe