### PR TITLE
fix duplicated API guide section

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -161,19 +161,6 @@
           <p><span data-i18n="direct_tip">直接使用 EdgeTTS 的完整音色名称进行调用。这种方式会绕过您的 OpenAI
             音色映射设置。</span></p>
           <pre class="bg-gray-100 dark:bg-gray-700 p-2 rounded"><code id="curl-example-direct">正在生成示例...</code></pre>
-          <pre><code id="api-endpoint-display">正在获取地址...</code></pre>
-          <h3 data-i18n="guide_openai">1. OpenAI 兼容格式 (推荐)</h3>
-          <p>
-            <span data-i18n="openai_tip">使用 OpenAI 的标准音色名 (`shimmer`, `alloy` 等)
-            调用，服务会自动映射到您在上面设置中选择的音色。</span>
-          </p>
-          <pre><code id="curl-example-openai">正在生成示例...</code></pre>
-          <h3 data-i18n="guide_direct">2. EdgeTTS 直接格式</h3>
-          <p>
-            <span data-i18n="direct_tip">直接使用 EdgeTTS 的完整音色名称进行调用。这种方式会绕过您的 OpenAI
-            音色映射设置。</span>
-          </p>
-          <pre><code id="curl-example-direct">正在生成示例...</code></pre>
         </div>
       </details>
 


### PR DESCRIPTION
## Summary
- remove repeated API guide section from the WebUI template

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853e35430348333bedce6146c1470a0