### PR TITLE
Fix PDF spaces for Chinese text

### DIFF
--- a/app.py
+++ b/app.py
@@ -161,7 +161,16 @@ def pre_process_text(text, options):
         processed_text = '\n'.join(reunited_lines)
     else:
         processed_text = processed_text.replace('\n', ' ')
-    return re.sub(r' +', ' ', processed_text.replace('\t', ' ')).strip()
+    processed_text = processed_text.replace('\t', ' ')
+    # Remove spaces inserted between Chinese characters due to PDF line breaks
+    processed_text = re.sub(r'(?<=[\u4e00-\u9fff])\s+(?=[\u4e00-\u9fff])', '', processed_text)
+    # Remove spaces around common Chinese punctuation
+    processed_text = re.sub(r'\s+([，。、？！；：])', r'\1', processed_text)
+    processed_text = re.sub(r'([，。、？！；：])\s+', r'\1', processed_text)
+    processed_text = re.sub(r'([（《「『])\s+', r'\1', processed_text)
+    processed_text = re.sub(r'\s+([）》」』])', r'\1', processed_text)
+    processed_text = re.sub(r' +', ' ', processed_text)
+    return processed_text.strip()
 
 def split_text_intelligently(text, options, target_size=800, max_size=1500):
     processed_text = pre_process_text(text, options)


### PR DESCRIPTION
## Summary
- improve Chinese text cleanup to remove spaces inserted by PDF line breaks

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import pre_process_text
print(pre_process_text('我 们 今天', {'remove_markdown':True,'remove_emoji':True,'no_urls':True,'no_line_breaks':True,'custom_keywords':''}))
PY`

------
https://chatgpt.com/codex/tasks/task_e_685402400fc08333bf45817ca8fab81a