### PR TITLE
Add Chrome extension for LocalTTS

### DIFF
--- a/chrome_extension/README.md
+++ b/chrome_extension/README.md
@@ -1,0 +1,6 @@
+# Chrome Extension for LocalTTS
+
+1. 在 Chrome 地址栏输入 `chrome://extensions/` 打开扩展管理页，开启“开发者模式”。
+2. 点击“加载已解压的扩展程序”，选择 `chrome_extension/` 目录。
+3. 在扩展图标的右键菜单或点击弹出页即可朗读网页内容。
+4. 先在扩展的“选项”页面中填写本地服务地址和 API Token。

--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -1,0 +1,27 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.contextMenus.create({
+    id: 'read-selection',
+    title: '朗读选中文本',
+    contexts: ['selection']
+  });
+  chrome.contextMenus.create({
+    id: 'read-page',
+    title: '朗读整页内容',
+    contexts: ['page']
+  });
+});
+
+async function capture(tabId, func) {
+  const [{ result }] = await chrome.scripting.executeScript({ target: { tabId }, func });
+  return result;
+}
+
+chrome.contextMenus.onClicked.addListener(async (info, tab) => {
+  if (info.menuItemId === 'read-selection') {
+    const text = await capture(tab.id, () => window.getSelection().toString());
+    chrome.storage.local.set({ pendingText: text || '' }, () => chrome.action.openPopup());
+  } else if (info.menuItemId === 'read-page') {
+    const text = await capture(tab.id, () => document.body.innerText);
+    chrome.storage.local.set({ pendingText: text || '' }, () => chrome.action.openPopup());
+  }
+});

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "LocalTTS Extension",
+  "description": "Read text aloud using LocalTTS service.",
+  "version": "0.1",
+  "icons": {
+    "128": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABLUlEQVR4nO3RQQ0AIBDAsAPbiAcZfbAqWLI1506crQN+1wCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagD1P4AJ6ZhGSRAAAAABJRU5ErkJggg=="
+  },
+  "permissions": ["storage", "activeTab", "scripting", "contextMenus"],
+  "host_permissions": ["http://*/v1/audio/*", "https://*/v1/audio/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABLUlEQVR4nO3RQQ0AIBDAsAPbiAcZfbAqWLI1506crQN+1wCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagD1P4AJ6ZhGSRAAAAABJRU5ErkJggg==",
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html"
+}

--- a/chrome_extension/options.html
+++ b/chrome_extension/options.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>LocalTTS Options</title>
+  <style>
+    body { font-family: sans-serif; width: 300px; }
+    label { display:block; margin-top:8px; }
+  </style>
+</head>
+<body>
+  <h2>LocalTTS 设置</h2>
+  <label>API 地址: <input type="text" id="api-url" value="http://127.0.0.1:5050" /></label>
+  <label>API Token: <input type="text" id="api-token" /></label>
+  <label>语言: <select id="language-select"></select></label>
+  <label>音色: <select id="voice-select"></select></label>
+  <button id="refresh-btn">刷新语音列表</button>
+  <button id="save-btn">保存</button>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/chrome_extension/options.js
+++ b/chrome_extension/options.js
@@ -1,0 +1,72 @@
+async function fetchVoices(url, token) {
+  try {
+    const res = await fetch(`${url}/v1/audio/all_voices`, {
+      headers: token ? { 'Authorization': 'Bearer ' + token } : {}
+    });
+    return await res.json();
+  } catch (e) {
+    console.error('Failed to fetch voices', e);
+    return [];
+  }
+}
+
+function populateLocales(voices, languageSelect) {
+  const locales = [...new Set(voices.map(v => v.locale))];
+  languageSelect.innerHTML = locales.map(l => `<option value="${l}">${l}</option>`).join('');
+}
+
+function populateVoices(voices, locale, voiceSelect) {
+  const filtered = voices.filter(v => v.locale === locale);
+  voiceSelect.innerHTML = filtered.map(v => `<option value="${v.name}">${v.short_name} (${v.gender})</option>`).join('');
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const urlInput = document.getElementById('api-url');
+  const tokenInput = document.getElementById('api-token');
+  const languageSelect = document.getElementById('language-select');
+  const voiceSelect = document.getElementById('voice-select');
+  const saveBtn = document.getElementById('save-btn');
+  const refreshBtn = document.getElementById('refresh-btn');
+
+  let allVoices = [];
+
+  async function loadConfig() {
+    const cfg = await chrome.storage.local.get({
+      apiUrl: 'http://127.0.0.1:5050',
+      apiToken: '',
+      language: '',
+      voice: ''
+    });
+    urlInput.value = cfg.apiUrl;
+    tokenInput.value = cfg.apiToken;
+    allVoices = await fetchVoices(cfg.apiUrl, cfg.apiToken);
+    populateLocales(allVoices, languageSelect);
+    if (cfg.language) {
+      languageSelect.value = cfg.language;
+      populateVoices(allVoices, cfg.language, voiceSelect);
+      if (cfg.voice) voiceSelect.value = cfg.voice;
+    }
+  }
+
+  languageSelect.addEventListener('change', () => {
+    populateVoices(allVoices, languageSelect.value, voiceSelect);
+  });
+
+  refreshBtn.addEventListener('click', async () => {
+    allVoices = await fetchVoices(urlInput.value, tokenInput.value);
+    populateLocales(allVoices, languageSelect);
+    populateVoices(allVoices, languageSelect.value, voiceSelect);
+  });
+
+  saveBtn.addEventListener('click', async () => {
+    await chrome.storage.local.set({
+      apiUrl: urlInput.value,
+      apiToken: tokenInput.value,
+      language: languageSelect.value,
+      voice: voiceSelect.value
+    });
+    alert('设置已保存');
+  });
+
+  loadConfig();
+});

--- a/chrome_extension/popup.html
+++ b/chrome_extension/popup.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>LocalTTS</title>
+  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABLUlEQVR4nO3RQQ0AIBDAsAPbiAcZfbAqWLI1506crQN+1wCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagD1P4AJ6ZhGSRAAAAABJRU5ErkJggg==">
+  <style>
+    body { font-family: sans-serif; width: 300px; }
+    button { margin: 4px; }
+    img.logo { width: 32px; height: 32px; }
+  </style>
+</head>
+<body>
+  <img class="logo" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAABLUlEQVR4nO3RQQ0AIBDAsAPbiAcZfbAqWLI1506crQN+1wCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagDUAawDWAKwBWAOwBmANwBqANQBrANYArAFYA7AGYA3AGoA1AGsA1gCsAVgDsAZgDcAagD1P4AJ6ZhGSRAAAAABJRU5ErkJggg==" alt="icon">
+  <button id="read-selection">朗读选中文本</button>
+  <button id="read-page">朗读整页</button>
+  <div>
+    <label>语言: <select id="language-select"></select></label>
+    <label>音色: <select id="voice-select"></select></label>
+  </div>
+  <audio id="audio" controls style="width:100%;"></audio>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome_extension/popup.js
+++ b/chrome_extension/popup.js
@@ -1,0 +1,99 @@
+let config = {};
+let allVoices = [];
+const audio = document.getElementById('audio');
+const langSelect = document.getElementById('language-select');
+const voiceSelect = document.getElementById('voice-select');
+
+async function loadConfig() {
+  config = await chrome.storage.local.get({
+    apiUrl: 'http://127.0.0.1:5050',
+    apiToken: '',
+    language: '',
+    voice: ''
+  });
+  await fetchVoices();
+  if (config.language) {
+    langSelect.value = config.language;
+    updateVoiceOptions(config.language);
+    voiceSelect.value = config.voice;
+  }
+}
+
+async function fetchVoices() {
+  try {
+    const res = await fetch(`${config.apiUrl.replace(/\/$/, '')}/v1/audio/all_voices`, {
+      headers: config.apiToken ? { 'Authorization': 'Bearer ' + config.apiToken } : {}
+    });
+    allVoices = await res.json();
+    const locales = [...new Set(allVoices.map(v => v.locale))];
+    langSelect.innerHTML = locales.map(l => `<option value="${l}">${l}</option>`).join('');
+  } catch(e) {
+    console.error(e);
+  }
+}
+
+function updateVoiceOptions(locale) {
+  const voices = allVoices.filter(v => v.locale === locale);
+  voiceSelect.innerHTML = voices.map(v => `<option value="${v.name}">${v.short_name} (${v.gender})</option>`).join('');
+}
+
+langSelect.addEventListener('change', () => updateVoiceOptions(langSelect.value));
+
+async function capture(tabId, func) {
+  const [{ result }] = await chrome.scripting.executeScript({ target: { tabId }, func });
+  return result;
+}
+
+async function speakText(text) {
+  if (!text) return;
+  const url = config.apiUrl.replace(/\/$/, '');
+  const headers = { 'Content-Type': 'application/json' };
+  if (config.apiToken) headers['Authorization'] = 'Bearer ' + config.apiToken;
+  const body = JSON.stringify({ model: 'tts-1', input: text, voice: voiceSelect.value, stream: true });
+  const response = await fetch(`${url}/v1/audio/speech`, { method: 'POST', headers, body });
+  const mediaSource = new MediaSource();
+  audio.src = URL.createObjectURL(mediaSource);
+  audio.play();
+  mediaSource.addEventListener('sourceopen', () => {
+    const sourceBuffer = mediaSource.addSourceBuffer('audio/mpeg');
+    const reader = response.body.getReader();
+    const pump = () => reader.read().then(({ done, value }) => {
+      if (done) {
+        if (sourceBuffer.updating) {
+          sourceBuffer.addEventListener('updateend', () => mediaSource.endOfStream(), { once: true });
+        } else {
+          mediaSource.endOfStream();
+        }
+        return;
+      }
+      sourceBuffer.appendBuffer(value);
+      if (sourceBuffer.updating) {
+        sourceBuffer.addEventListener('updateend', pump, { once: true });
+      } else {
+        pump();
+      }
+    });
+    pump();
+  });
+}
+
+document.getElementById('read-selection').addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const text = await capture(tab.id, () => window.getSelection().toString());
+  speakText(text);
+});
+
+document.getElementById('read-page').addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const text = await capture(tab.id, () => document.body.innerText);
+  speakText(text);
+});
+
+chrome.storage.local.get('pendingText').then(data => {
+  if (data.pendingText) {
+    speakText(data.pendingText);
+    chrome.storage.local.remove('pendingText');
+  }
+});
+
+loadConfig();


### PR DESCRIPTION
## Summary
- add `chrome_extension` with manifest and icons
- provide popup and options pages to configure API and play audio
- implement background script with context menu support
- include README with loading instructions
- use base64 encoded icon in manifest and popup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854f5e8215083339020395c76632d6e